### PR TITLE
[Docs] Add docs/README.md with summary and links to OctoAcme project management processes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,64 @@
+# OctoAcme Project Management Documentation
+
+Welcome — this folder contains OctoAcme's Project Management process docs. Use this README as the single entry point to understand how we run projects and where to find process details, templates, and checklists.
+
+## Brief overview of OctoAcme project management processes
+OctoAcme organizes delivery around a lightweight lifecycle and clear roles to reduce friction and increase predictability:
+
+- Initiation
+  - Validate the problem and measurable outcomes.
+  - Capture a Project One-pager and confirm stakeholders.
+  - Decide go/no-go to enter planning.
+  - See: Project Initiation Guide.
+
+- Planning
+  - Turn approved initiatives into a prioritized, estimated backlog and release plan.
+  - Define Definition of Done, dependencies, and a risk register.
+  - See: Project Planning.
+
+- Execution & Tracking
+  - Run predictable delivery rhythms (standups, weekly delivery syncs, demos).
+  - Use the project board and PR workflows to manage work.
+  - Track velocity, blockers, and key metrics.
+  - See: Execution & Tracking.
+
+- Risk Management & Communication
+  - Maintain a Risk Register, review risks weekly, and follow defined escalation paths.
+  - Use single-source status updates for stakeholders.
+  - See: Risk Management & Communication.
+
+- Release & Deployment
+  - Follow pre-release checks (CI, security scans, release notes, rollback plan).
+  - Automate deployments where possible and verify post-deploy.
+  - See: Release & Deployment Guide.
+
+- Retrospective & Continuous Improvement
+  - Run retrospectives after sprints, releases, and incidents.
+  - Convert action items into backlog issues and track impact.
+  - See: Retrospective & Continuous Improvement.
+
+## Team roles & responsibilities
+- Project Manager (PM): coordinates delivery, risk, and stakeholder communications.
+- Product Manager (PdM): defines outcomes and prioritizes work.
+- Developers, QA, and other contributors: implement, test, and verify features.
+- See: Roles and Personas.
+
+## Docs index
+- [Project Management Overview](./octoacme-project-management-overview.md)
+- [Project Initiation Guide](./octoacme-project-initiation.md)
+- [Project Planning](./octoacme-project-planning.md)
+- [Execution & Tracking](./octoacme-execution-and-tracking.md)
+- [Risk Management & Communication](./octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](./octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](./octoacme-retrospective-and-continuous-improvement.md)
+- [Roles and Personas](./octoacme-roles-and-personas.md)
+
+## How to use & maintain these docs
+- Keep the one-pager, risk register, and release notes updated in the project repo.
+- Add new process artifacts here in docs/ and reference them from project READMEs.
+- If you update process content, use the "Add Content to Project Management Process Docs" issue template so changes are reviewed.
+
+## Acceptance criteria
+- Content aligns with existing process docs
+- Update improves clarity or closes a documented gap
+- Proposed content has been reviewed with stakeholders (if needed)


### PR DESCRIPTION
Adds a top-level README in docs/ that summarizes OctoAcme’s project management lifecycle, roles, rhythms, and links to all existing process documents.
This PR implements the request in issue #2 and provides a single entry point for onboarding and process discovery.
Related issue: refs #2